### PR TITLE
Adding .nojekyll to prevent GitHub Pages from using Jekyll.

### DIFF
--- a/docs/.nojekyll
+++ b/docs/.nojekyll
@@ -1,0 +1,1 @@
+TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.


### PR DESCRIPTION
Adding .nojekyll to prevent GitHub Pages from using Jekyll.